### PR TITLE
feat: 눈 사진 찍어서 사시 여부 판정 요청 및 결과 저장 & 결과 페이지 라우팅

### DIFF
--- a/gymi/lib/screens/bad_screen.dart
+++ b/gymi/lib/screens/bad_screen.dart
@@ -1,0 +1,33 @@
+import 'package:eyedid_flutter_example/%08screens/home_screen.dart';
+import 'package:flutter/material.dart';
+
+class BadScreen extends StatelessWidget {
+  final bool isVibrant;
+  const BadScreen({super.key, required this.isVibrant});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Eye Status: 🤔', style: TextStyle(fontSize: 24)),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => HomeScreen(isVibrant: isVibrant)
+                    )
+                );
+              },
+              child: const Text('홈 화면으로 가기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/gymi/lib/screens/color_select_screen.dart
+++ b/gymi/lib/screens/color_select_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:eyedid_flutter_example/%08screens/calibration_screen.dart';
+import 'package:eyedid_flutter_example/%08screens/eye_judge_screen.dart';
 import 'package:eyedid_flutter_example/%08screens/home_screen.dart';
 import 'package:eyedid_flutter_example/service/gaze_tracker_service.dart';
 import 'package:flutter/material.dart';
@@ -100,11 +101,7 @@ class _ColorSelectState extends State<ColorSelectScreen> {
                       onTap: () {
                         Navigator.push(
                           context,
-                          MaterialPageRoute(
-                              builder: (context) =>
-                                  HomeScreen(isVibrant: isVibrant)
-                              // 예시로 secondScreen을 넣으면 수정할 것
-                              ),
+                          MaterialPageRoute(builder: (context) => EyeJudgeScreen(isVibrant: isVibrant)),
                         );
                       },
                       child: Image.asset(

--- a/gymi/lib/screens/eye_judge_screen.dart
+++ b/gymi/lib/screens/eye_judge_screen.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'package:camera/camera.dart';
+import 'package:eyedid_flutter_example/%08screens/bad_screen.dart';
+import 'package:eyedid_flutter_example/%08screens/good_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class EyeJudgeScreen extends StatefulWidget {
+  final bool isVibrant;
+  const EyeJudgeScreen({super.key, required this.isVibrant});
+
+  @override
+  State<EyeJudgeScreen> createState() => _EyeJudgeScreenState();
+}
+
+class _EyeJudgeScreenState extends State<EyeJudgeScreen> {
+  late CameraController _controller;
+  bool _isReady = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initCamera();
+  }
+
+  Future<void> _initCamera() async {
+    final cameras = await availableCameras();
+    final front = cameras.firstWhere(
+          (camera) => camera.lensDirection == CameraLensDirection.front,
+    );
+
+    _controller = CameraController(front, ResolutionPreset.medium);
+    await _controller.initialize();
+    setState(() => _isReady = true);
+  }
+
+  Future<void> _takeAndSendPicture() async {
+    final file = await _controller.takePicture();
+
+    final request = http.MultipartRequest(
+      'POST',
+      Uri.parse('http://gymi.com/upload-eyes'),  // TODO: api 명세 정해지면 바꾸기
+    );
+    request.files.add(await http.MultipartFile.fromPath('image', file.path)); // TODO: api 명세 정해지면 바꾸기
+
+    final response = await request.send();
+    final body = await response.stream.bytesToString();
+    final result = jsonDecode(body);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('eyeStatus', result['eyeStatus']); // TODO: api 명세 정해지면 바꾸기
+
+    if (result['eyeStatus'] == 'GOOD') { // TODO: api 명세 정해지면 바꾸기
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => GoodScreen(isVibrant: widget.isVibrant), // widget.isVibrant으로 접근
+        ),
+      );
+    } else {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => BadScreen(isVibrant: widget.isVibrant), // widget.isVibrant으로 접근
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isReady) return const Center(child: CircularProgressIndicator());
+
+    final screenHeight = MediaQuery.of(context).size.height;
+    final rectTop = screenHeight / 3;
+    const rectHeight = 150.0;
+
+    return Scaffold(
+      body: Stack(
+        children: [
+          CameraPreview(_controller),
+          _overlayGuide(rectTop, rectHeight),
+          Positioned(
+            bottom: 40,
+            left: MediaQuery.of(context).size.width / 2 - 30,
+            child: FloatingActionButton(
+              onPressed: _takeAndSendPicture,
+              child: const Icon(Icons.camera_alt),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _overlayGuide(double rectTop, double rectHeight) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Container(color: Colors.black.withOpacity(0.4)),
+        ),
+        Positioned(
+          top: rectTop,
+          left: 30,
+          right: 30,
+          child: Container(
+            height: rectHeight,
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.white, width: 2),
+              color: Colors.transparent,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/gymi/lib/screens/good_screen.dart
+++ b/gymi/lib/screens/good_screen.dart
@@ -1,0 +1,33 @@
+import 'package:eyedid_flutter_example/%08screens/home_screen.dart';
+import 'package:flutter/material.dart';
+
+class GoodScreen extends StatelessWidget {
+  final bool isVibrant;
+  const GoodScreen({super.key, required this.isVibrant});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Eye Status: 😄', style: TextStyle(fontSize: 24)),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => HomeScreen(isVibrant: isVibrant)
+                    )
+                );
+              },
+              child: const Text('홈 화면으로 가기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 🪐 작업 내용

- 컬러모드에서 다음 화면으로 넘어가면 눈 사진 찍어서 사시 여부 판정하는 api로 요청을 보냅니다.
- api 응답값을 로컬에 저장하고, 응답값에 따라 GoodScreen과 BadScreen으로 라우팅합니다.
- GoodScreen과 BadScreen에서 버튼을 누르면 HomeScreen으로 라우팅합니다.
- 디자인은 아직 적용 안 하고, 기능만 구현했습니다.
- api 명세 나오면 요청 주소랑 응답 값 파싱하는 부분 수정해야합니다. (TODO 부분)

## 📸 스크린샷(선택)

로그인 -> 컬러모드선택 -> 눈 사진 찍기 -> 사시판정결과 -> 홈화면
(사시 판정 관련 api가 아직 없어서 이 영상 찍을 때는 무조건 GoodScreen으로 라우팅하도록 하고 촬영했습니다.)

https://github.com/user-attachments/assets/8d644150-1f6c-4298-861f-d6e5dbb518f2

